### PR TITLE
Fix typo with isBootstrapped

### DIFF
--- a/packages/unstated-action-proxy/src/unstated-action-proxy.js
+++ b/packages/unstated-action-proxy/src/unstated-action-proxy.js
@@ -49,4 +49,4 @@ export class PersistContainer<State: Object> extends Container<State> {
   }
 }
 
-export const isBoostrapped = (container: Container<*>) => container.state._persist_version !== undefined
+export const isBootstrapped = (container: Container<*>) => container.state._persist_version !== undefined

--- a/packages/unstated-persist-gate/src/index.js
+++ b/packages/unstated-persist-gate/src/index.js
@@ -3,7 +3,7 @@
 // @NOTE this component is just a conveinence, child can easily just check `if (![containersICareAbout].every(isBootstrapped)) ...`
 import React from 'react'
 import { Subscribe } from 'unstated'
-import { isBoostrapped } from 'unstated-persist'
+import { isBootstrapped } from 'unstated-persist'
 
 type SubscribeProps = {
   loading: React.ReactNode,
@@ -16,7 +16,7 @@ export default function SubscribeGate(props: SubscribeProps): React.ReactNode {
       {(...args) => {
         if (
           !this.bootstrapped &&
-          args.every(isBoostrapped)
+          args.every(isBootstrapped)
         )
           this.bootstrapped = true;
         if (this.bootstrapped) return props.children(...args);

--- a/packages/unstated-persist/src/unstated-persist.js
+++ b/packages/unstated-persist/src/unstated-persist.js
@@ -49,4 +49,4 @@ export class PersistContainer<State: Object> extends Container<State> {
   }
 }
 
-export const isBoostrapped = (container: Container<*>) => container.state._persist_version !== undefined
+export const isBootstrapped = (container: Container<*>) => container.state._persist_version !== undefined

--- a/packages/unstated-persist/src/unstated-persist.js
+++ b/packages/unstated-persist/src/unstated-persist.js
@@ -31,6 +31,8 @@ export class PersistContainer<State: Object> extends Container<State> {
             if (process.env.NODE_ENV !== 'production') console.log('unstated-persist: state version mismatch, skipping rehydration')
             this.setState(persistStatePartial)
           } else this.setState(incomingState) // state versions match, set state as is
+        } else {
+          this.setState(persistStatePartial)
         }
       } catch (err) {
         this.setState(persistStatePartial)


### PR DESCRIPTION
When `import { isBootstrapped } from 'unstated-persist';` it fails because the [exported function](https://github.com/rt2zz/unstated-persist/blob/master/packages/unstated-persist/src/unstated-persist.js#L52) is called `isBoostrapped` instead of `isBootstrapped`.


